### PR TITLE
Store canonpath for stringification

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -20,15 +20,16 @@ use File::Temp 0.18 ();
 our @EXPORT = qw/path/;
 
 use constant {
-    PATH => 0,
-    VOL  => 1,
-    DIR  => 2,
-    FILE => 3,
-    TEMP => 4,
+    PATH  => 0,
+    CPATH => 1,
+    VOL   => 2,
+    DIR   => 3,
+    FILE  => 4,
+    TEMP  => 5,
 };
 
 use overload (
-    q{""}    => sub    { $_[0]->[PATH] },
+    q{""}    => sub    { $_[0]->[CPATH] },
     bool     => sub () { 1 },
     fallback => 1,
 );
@@ -59,10 +60,10 @@ sub path {
     $path = "." unless length $path;
     # join stringifies any objects, too, which is handy :-)
     $path = join( "/", ( $path eq '/' ? "" : $path ), @_ ) if @_;
-    $path = File::Spec->canonpath($path); # ugh, but probably worth it
+    my $cpath = $path = File::Spec->canonpath($path); # ugh, but probably worth it
     $path =~ tr[\\][/];                   # unix convention enforced
     $path =~ s{/$}{} if $path ne "/";     # hack to make splitpath give us a basename
-    bless [$path], __PACKAGE__;
+    bless [$path, $cpath], __PACKAGE__;
 }
 
 =construct new
@@ -703,7 +704,7 @@ Returns a string representation of the path.
 
 =cut
 
-sub stringify { $_[0]->[PATH] }
+sub stringify { $_[0]->[CPATH] }
 
 =method touch
 

--- a/t/temp.t
+++ b/t/temp.t
@@ -26,8 +26,8 @@ subtest "tempfile" => sub {
 subtest "tempfile handle" => sub {
     my $tempfile = Path::Tiny->tempfile;
     my $fh       = $tempfile->filehandle;
-    is( ref $tempfile->[4], 'File::Temp', "cached File::Temp object" );
-    is( fileno $tempfile->[4], undef, "cached handle is closed" );
+    is( ref $tempfile->[5], 'File::Temp', "cached File::Temp object" );
+    is( fileno $tempfile->[5], undef, "cached handle is closed" );
 };
 
 done_testing;


### PR DESCRIPTION
This is mostly for proper display on Win32.  My project would like to switch from Path::Class to Path::Tiny, but need the display to have the slashes in the proper direction on that platform when stringified.  

Not exactly elegant, you might have a different way to achieve this (if you want to at all).
