### PR TITLE
Change remove() so it returns false if the file does not exist.

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -680,18 +680,22 @@ sub relative { path( File::Spec->abs2rel( $_[0]->[PATH], $_[1] ) ) }
 For directories, this is like like calling C<remove_tree> from L<File::Path>.  An
 optional hash reference is passed through to C<remove_tree>.
 
-For files, the file is unlinked if it exists.  Unlike C<unlink>, if the file
-does not exist, this silently does nothing and returns a true value anyway.
+For files, the file is unlinked if it exists.
+
+If the path does not exist, it returns false.
 
 =cut
 
 sub remove {
     my ( $self, $opts ) = @_;
-    if ( -d $self->[PATH] ) {
+    if ( !-e $self->[PATH] ) {
+        return 0;
+    }
+    elsif ( -d $self->[PATH] ) {
         return File::Path::remove_tree( $self->[PATH], ref($opts) eq 'HASH' ? $opts : () );
     }
     else {
-        return ( -e $self->[PATH] ) ? unlink $self->[PATH] : 1;
+        return unlink $self->[PATH];
     }
 }
 

--- a/t/filesystem.t
+++ b/t/filesystem.t
@@ -67,7 +67,7 @@ ok( $file->stat->mtime > ( time - 10 ), "touch sets utime" );
 
 ok $dir->remove, "Removed $dir";
 ok !-e $dir, "$dir no longer exists";
-ok $dir->remove, "Removing non-existent dir returns true";
+ok !$dir->remove, "Removing non-existent dir returns false";
 
 my $tmpdir = Path::Tiny->tempdir;
 
@@ -157,7 +157,7 @@ my $tmpdir = Path::Tiny->tempdir;
 
     ok( $file->remove, "removing file" );
     ok !-e $file, "file is gone";
-    ok $file->remove, "removing file again returns true";
+    ok !$file->remove, "removing file again returns false";
 }
 
 {


### PR DESCRIPTION
Currently there is no way remove() can return false.  If the unlink fails it will throw
an exception.  Its better to give the user useful information about whether anything
was removed.

For #17
