### PR TITLE
move() with File::Copy::move()

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -339,7 +339,8 @@ Copies a file using L<File::Copy>'s C<copy> function.
 
 # XXX do recursively for directories?
 sub copy {
-    File::Copy::copy( $_[0]->[PATH], "$_[1]" ) or Carp::croak("copy failed: $!");
+    Carp::croak("Missing destination for copy()")            if @_ == 1;
+    File::Copy::copy( $_[0]->[PATH], "$_[1]" ) or Carp::croak("Can't copy('$_[0]', '$_[1]'): $!");
 }
 
 =method dirname

--- a/t/filesystem.t
+++ b/t/filesystem.t
@@ -233,8 +233,26 @@ note "copy"; {
         skip "No exception if run as root", 1 if $> == 0;
         skip "No exception writing to read-only file", 1
           unless exception { open my $fh, ">", "$copy" or die }; # probe if actually read-only
-        ok( exception { $file->copy($copy) }, "copy throws error if permission denied" );
+        like(
+            exception { $file->copy($copy) },
+            qr/^Can't copy\('\Q$file\E', '\Q$copy\E'\): /,
+            "copy throws error if permission denied"
+        );
     }
+}
+
+
+note "copy, no arguments"; {
+    my $file = Path::Tiny->tempfile;
+
+    $file->spew("Hello World\n");
+
+    like(
+        exception { $file->copy },
+        qr/^Missing destination for copy\(\) at \Q$0 line/,
+        "copy with no argument throws an error"
+    );
+    is( $file->slurp, "Hello World\n",        "  and the file is unaffected" );
 }
 
 


### PR DESCRIPTION
The rename() documentation says "behavior of this function varies wildly depending on your system implementation."  That's no good, Perl is supposed to protect you from that.  The most common problem with rename is whether it will rename across filesystem boundaries.

This uses File::Copy::move which protects the user from rename's quirks.  I also fixed up the error handling of copy on the way.
