### PR TITLE
Startup diet

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -9,6 +9,7 @@ package Path::Tiny;
 # Dependencies
 use autodie 2.14; # autodie::skip support
 use Exporter 5.57   (qw/import/);
+use File::Spec 3.40 ();
 use Carp       ();
 
 our @EXPORT = qw/path/;
@@ -67,7 +68,6 @@ sub path {
       unless defined $path && length $path;
     # join stringifies any objects, too, which is handy :-)
     $path = join( "/", ( $path eq '/' ? "" : $path ), @_ ) if @_;
-    require File::Spec;
     my $cpath = $path = File::Spec->canonpath($path); # ugh, but probably worth it
     $path =~ tr[\\][/];                               # unix convention enforced
     $path =~ s{/$}{} if $path ne "/"; # hack to make splitpath give us a basename
@@ -108,10 +108,7 @@ picky for C<path("/")>.
 
 =cut
 
-sub rootdir {
-    require File::Spec;
-    return path( File::Spec->rootdir );
-}
+sub rootdir { path( File::Spec->rootdir ) }
 
 =construct tempfile
 
@@ -189,8 +186,7 @@ sub _parse_file_temp_args {
 
 sub _splitpath {
     my ($self) = @_;
-    require File::Spec;
-    return @{$self}[ VOL, DIR, FILE ] = File::Spec->splitpath( $self->[PATH] );
+    @{$self}[ VOL, DIR, FILE ] = File::Spec->splitpath( $self->[PATH] );
 }
 
 #--------------------------------------------------------------------------#
@@ -732,10 +728,7 @@ C<< File::Spec->abs2rel() >>.
 =cut
 
 # Easy to get wrong, so wash it through File::Spec (sigh)
-sub relative {
-    require File::Spec;
-    return path( File::Spec->abs2rel( $_[0]->[PATH], $_[1] ) );
-}
+sub relative { path( File::Spec->abs2rel( $_[0]->[PATH], $_[1] ) ) }
 
 =method remove
 


### PR DESCRIPTION
This branch cuts down the startup time of Path::Tiny by about 30% (from 100ms to 70ms on my Macbook) by loading modules on demand.

Unfortunately the overwhelming bulk of startup time is autodie, but recovering 30% isn't bad.
