### PR TITLE
Error messages of copy() should include filenames

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -395,8 +395,9 @@ Copies a file using L<File::Copy>'s C<copy> function.
 
 # XXX do recursively for directories?
 sub copy {
+    my($self, $dest) = @_;
     require File::Copy;
-    File::Copy::copy( $_[0]->[PATH], "$_[1]" ) or Carp::croak("copy failed: $!");
+    File::Copy::copy( $self->[PATH], $dest ) or Carp::croak("copy failed for $self to $dest: $!");
 }
 
 =method dirname

--- a/t/filesystem.t
+++ b/t/filesystem.t
@@ -236,7 +236,10 @@ my $tmpdir = Path::Tiny->tempdir;
         skip "No exception if run as root", 1 if $> == 0;
         skip "No exception writing to read-only file", 1
           unless exception { open my $fh, ">", "$copy" or die }; # probe if actually read-only
-        ok( exception { $file->copy($copy) }, "copy throws error if permission denied" );
+        my $error = exception { $file->copy($copy) };
+        ok( $error,  "copy throws error if permission denied" );
+        like( $error, qr/\Q$file/, "error messages includes the source file name" );
+        like( $error, qr/\Q$copy/, "error messages includes the destination file name" );
     }
 }
 


### PR DESCRIPTION
Hi,

I've improve error messages of `copy()` with tests. Can you review my changes please?
