### PR TITLE
add utime method

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -978,9 +978,11 @@ sub stringify { $_[0]->[PATH] }
 =method touch
 
     path("foo.txt")->touch;
+    path("foo.txt")->touch($epoch_secs);
 
 Like the Unix C<touch> utility.  Creates the file if it doesn't exist, or else
-changes the modification and access times to the current time.
+changes the modification and access times to the current time.  If the first
+argument is the epoch seconds then it will be used.
 
 Returns the path object so it can be easily chained with spew:
 
@@ -989,15 +991,14 @@ Returns the path object so it can be easily chained with spew:
 =cut
 
 sub touch {
-    my ($self) = @_;
-    if ( -e $self->[PATH] ) {
-        my $now = time();
-        utime $now, $now, $self->[PATH] or _throw( 'utime', [ $now, $now, $self->[PATH] ] );
-    }
-    else {
+    my ( $self, $epoch ) = @_;
+    if ( ! -e $self->[PATH] ) {
         my $fh = $self->openw;
         close $fh or _throw( 'close', [$fh] );
     }
+    $epoch = defined($epoch) ? $epoch : time();
+    utime $epoch, $epoch, $self->[PATH]
+        or _throw( 'utime', [ $epoch, $epoch, $self->[PATH] ] );
     return $self;
 }
 

--- a/t/filesystem.t
+++ b/t/filesystem.t
@@ -61,9 +61,12 @@ ok $dir->is_dir, "It's a directory!";
 $file = $dir->child('foo.x');
 $file->touch;
 ok -e $file;
-utime time - 10, time - 10, $file;
+my $epoch = time - 10;
+utime $epoch, $epoch, $file;
 $file->touch;
-ok( $file->stat->mtime > ( time - 10 ), "touch sets utime" );
+ok( $file->stat->mtime > $epoch, "touch sets utime as current time" );
+$file->touch($epoch);
+ok( $file->stat->mtime == $epoch, "touch sets utime as 10 secs before" );
 
 {
     my @files = $dir->children;


### PR DESCRIPTION
I usually use utime core function when downloading file from Web server.
Like this:

```
# ...
$dir->child($file)->spew_raw( $res->{content} );

my $res = HTTP::Tiny->new->get("$url/$file");
if ( $res->{headers}{'last-modified'} ) {
    my $dt = DateTime::Format::HTTP->parse_datetime(
        $res->{headers}{'last-modified'},
    );
    utime $dt->epoch, $dt->epoch, $dir->child($file)->canonpath;
    #$dir->child($file)->utime($atime, $mtime); <-- ?
}
# ...
```

It'll be convenient if utime is supported from Path::Tiny.
If this is not proper for Path::Tiny, please just ignore this pull-req. :-)
