### PR TITLE
fail case for ->parent

### DIFF
--- a/t/parent.t
+++ b/t/parent.t
@@ -49,5 +49,8 @@ while (@cases) {
     };
 }
 
+my $path = '/foo..bar.txt';
+my $expected = '/';
+is(path($path)->parent, $expected, qq{parent($path): $path => $expected});
 done_testing;
 # COPYRIGHT


### PR DESCRIPTION
I believe that directly using File::Basename's "dirname" (which is core since perl 5.000) should fix this issue, even for Windows.
