### PR TITLE
Remove uses of Test::Deep from test suite.

### DIFF
--- a/t/children.t
+++ b/t/children.t
@@ -2,7 +2,6 @@ use 5.008001;
 use strict;
 use warnings;
 use Test::More 0.96;
-use Test::Deep '!blessed';
 use File::Basename ();
 use File::Temp ();
 use File::Spec::Unix;
@@ -16,14 +15,14 @@ path($tempdir)->child($_)->touch for @kids;
 
 my @expected = map { path( File::Spec::Unix->catfile( $tempdir, $_ ) ) } @kids;
 
-cmp_deeply(
+is_deeply(
     [ sort { $a cmp $b } path($tempdir)->children ],
     [ sort @expected ],
     "children correct"
 );
 
 my $regexp = qr/.a/;
-cmp_deeply(
+is_deeply(
     [ sort { $a cmp $b } path($tempdir)->children($regexp) ],
     [ sort grep { my $child = File::Basename::basename($_); $child =~ /$regexp/ } @expected ],
     "children correct with Regexp argument"

--- a/t/exports.t
+++ b/t/exports.t
@@ -3,7 +3,6 @@ use strict;
 use warnings;
 use Test::More 0.96;
 use Test::FailWarnings;
-use Test::Deep '!blessed';
 use Test::Fatal;
 
 use Path::Tiny qw/path cwd rootdir tempdir tempfile/;

--- a/t/recurse.t
+++ b/t/recurse.t
@@ -3,7 +3,6 @@ use strict;
 use warnings;
 use Test::More 0.92;
 use File::Temp;
-use Test::Deep qw/cmp_deeply/;
 use File::pushd qw/tempd/;
 use Config;
 
@@ -41,7 +40,7 @@ subtest 'no symlinks' => sub {
         push @files, "$f";
     }
 
-    cmp_deeply( [sort @files], [sort @breadth], "Breadth first iteration" )
+    is_deeply( [sort @files], [sort @breadth], "Breadth first iteration" )
       or diag explain \@files;
 
 };
@@ -97,7 +96,7 @@ subtest 'with symlinks' => sub {
         while ( my $f = $iter->() ) {
             push @files, "$f";
         }
-        cmp_deeply( [sort @files], [sort @nofollow], "Don't follow symlinks" )
+        is_deeply( [sort @files], [sort @nofollow], "Don't follow symlinks" )
         or diag explain \@files;
     };
 
@@ -107,7 +106,7 @@ subtest 'with symlinks' => sub {
         while ( my $f = $iter->() ) {
             push @files, "$f";
         }
-        cmp_deeply( [sort @files], [sort @follow], "Follow symlinks" )
+        is_deeply( [sort @files], [sort @follow], "Follow symlinks" )
             or diag explain \@files;
     };
 };

--- a/t/temp.t
+++ b/t/temp.t
@@ -2,7 +2,6 @@ use 5.008001;
 use strict;
 use warnings;
 use Test::More 0.96;
-use Test::Deep '!blessed';
 use File::Spec::Unix;
 use File::pushd qw/tempd/;
 


### PR DESCRIPTION
This is my first PR in the interest of making Path::Tiny tinier.

Two test files load Test::Deep but do not use it; these were trivial to eliminate.

In two other test files, Test::Deep can be easily replaced with `is_deeply` from Test::More.

Test::Deep itself has non-core dependencies - it depends on Test::NoWarnings, which depends on Test::Tester. So this cuts out more than one dependency.
