### PR TITLE
Eliminate testing dependency on Devel::Hide

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -31,6 +31,7 @@ stopwords = utf
 [RemovePrereqs]
 remove = Unicode::UTF8
 remove = Path::Class
+remove = Devel::Hide
 
 ; Digest/Digest::SHA are fine in 5.10.0+
 [Prereqs]
@@ -41,3 +42,6 @@ File::Temp = 0.18
 
 [Prereqs / Recommends]
 Unicode::UTF8 = 0.58
+
+[Prereqs / TestRecommends]
+Devel::Hide = 0

--- a/t/input_output_no_UU.t
+++ b/t/input_output_no_UU.t
@@ -3,6 +3,11 @@ use strict;
 use warnings;
 use Test::More 0.96;
 
+BEGIN {
+    eval { require Devel::Hide }
+        or plan skip_all => 'this test requires Devel::Hide';
+};
+
 use Devel::Hide qw/Unicode::UTF8/;
 use Path::Tiny;
 


### PR DESCRIPTION
This makes the dependency optional.
