### PR TITLE
Fix t/locking.t under (at least) FreeBSD 9

### DIFF
--- a/t/locking.t
+++ b/t/locking.t
@@ -17,7 +17,7 @@ if ($IS_BSD) {
     # is temp partition lockable?
     my $file = Path::Tiny->tempfile;
     open my $fh, ">>", $file;
-    flock $fh, "LOCK_EX"
+    flock $fh, LOCK_EX
       or plan skip_all => "Can't lock tempfiles on this OS/filesystem";
 }
 


### PR DESCRIPTION
Trying to `cpanm Path::Tiny` under FreeBSD produces the following error:

```
#   Failed test 'Test::FailWarnings should catch no warnings'
#   at t/locking.t line 20.
# Warning was 'Argument "LOCK_EX" isn't numeric in flock at t/locking.t line 20.'
# Tests were run but no plan was declared and done_testing() was not seen.
t/locking.t ............. skipped: Can't lock tempfiles on this OS/filesystem
```

Removing the quotes around LOCK_EX fixes the problem.
