### PR TITLE
prevent flock package from being indexed

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -76,10 +76,11 @@ sub _is_root {
 # flock doesn't work on NFS on BSD.  Since program authors often can't control
 # or detect that, we warn once instead of being fatal if we can detect it and
 # people who need it strict can fatalize the 'flock' category
-
-#<<< No perltidy
-{ package flock; use if Path::Tiny::IS_BSD(), 'warnings::register' }
-#>>>
+{
+    package #hide from PAUSE
+        flock;
+    use if Path::Tiny::IS_BSD(), 'warnings::register'
+}
 
 my $WARNED_BSD_NFS = 0;
 


### PR DESCRIPTION
Path-Tiny is currently the indexed dist for the flock module, when all it wants to do is register a warning category.
