### PR TITLE
Filename with backslash

### DIFF
--- a/t/backslash.t
+++ b/t/backslash.t
@@ -17,7 +17,7 @@ plan tests => 2 + 9 * @testfiles;
 ok chdir $tmpdir;
 
 for my $testfile (@testfiles) {
-  SKIP: {
+    SKIP: {
         open my $fh, '>', $testfile
           or skip "Cannot create $testfile on this platform.", 9;
 


### PR DESCRIPTION
Hi,

I really love this module and use it all over since I first read about it in the Perl advent calendar, so first of all thank you very much for publishing it!

However, today I encountered a problem with a script trying to traverse a directory tree, which failed for some files the names of which contained a backslash. While one might argue that it is perhaps not the best design decision to use such filenames in the first place, I still find it somewhat strange that an ->iterator() will return defective objects (with backslashes converted to slashes) in this case. (Which in pathologic cases might even refer to different files in a subdirectory.)

So here is a test file for that issue.

BTW, my tests (and in fact the whole test suite) would work (at least for me ☺) if one just commented out the "$path =~ tr[\][/]; # unix convention enforced" line in lib/Path/Tiny.pm. I have not done that in my commit, though, since I guess you had put that code in there for some reason.

Kind regards,
fany
