### PR TITLE
Reduce memory consumption when digesting a huge file.

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -615,7 +615,11 @@ sub digest {
     my ( $self, $alg, @args ) = @_;
     $alg = 'SHA-256' unless defined $alg;
     require Digest;
-    return Digest->new( $alg, @args )->add( $self->slurp_raw )->hexdigest;
+    my $digest = Digest->new( $alg, @args );
+    my $fh = $self->filehandle( { locked => 1 }, "<", ":unix" );
+    my $buf;
+    $digest->add($buf) while read $fh, $buf, 4096;
+    return $digest->hexdigest;
 }
 
 =method dirname


### PR DESCRIPTION
I usually use `digest()` method to check my downloaded files such like huge zip archives and ISO images. And I realized that it consumes  memory as its file size too late. So out of memory is occurred too often when I tried to digesting big file in a low-end PC like virtual machine.

Current version of digest() method uses `slurp_raw()` to add content to `Digest` object(sorry, it was my fault). If you tried to digest with a huge file, then your memory will be used excessively as your file size. This patch solve the problem by reading 4KB unit each time.

I've used `4096` constant, so if it is not proper value then please adjust it. :)
