### PR TITLE
Fix _check_UU sub

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -459,7 +459,7 @@ sub append {
 sub append_raw { splice @_, 1, 0, { binmode => ":unix" }; goto &append }
 
 sub append_utf8 {
-    if ( defined($HAS_UU) ? $HAS_UU : $HAS_UU = _check_UU() ) {
+    if ( defined($HAS_UU) ? $HAS_UU : ($HAS_UU = _check_UU()) ) {
         my $self = shift;
         append( $self, { binmode => ":unix" }, map { Unicode::UTF8::encode_utf8($_) } @_ );
     }
@@ -998,7 +998,7 @@ sub lines_raw {
 sub lines_utf8 {
     my $self = shift;
     my $args = _get_args( shift, qw/binmode chomp count/ );
-    if (   ( defined($HAS_UU) ? $HAS_UU : $HAS_UU = _check_UU() )
+    if (   ( defined($HAS_UU) ? $HAS_UU : ($HAS_UU = _check_UU()) )
         && $args->{chomp}
         && !$args->{count} )
     {
@@ -1343,7 +1343,7 @@ sub slurp {
 sub slurp_raw { $_[1] = { binmode => ":unix" }; goto &slurp }
 
 sub slurp_utf8 {
-    if ( defined($HAS_UU) ? $HAS_UU : $HAS_UU = _check_UU() ) {
+    if ( defined($HAS_UU) ? $HAS_UU : ($HAS_UU = _check_UU()) ) {
         return Unicode::UTF8::decode_utf8( slurp( $_[0], { binmode => ":unix" } ) );
     }
     else {
@@ -1399,7 +1399,7 @@ sub spew {
 sub spew_raw { splice @_, 1, 0, { binmode => ":unix" }; goto &spew }
 
 sub spew_utf8 {
-    if ( defined($HAS_UU) ? $HAS_UU : $HAS_UU = _check_UU() ) {
+    if ( defined($HAS_UU) ? $HAS_UU : ($HAS_UU = _check_UU()) ) {
         my $self = shift;
         spew( $self, { binmode => ":unix" }, map { Unicode::UTF8::encode_utf8($_) } @_ );
     }


### PR DESCRIPTION
The precedence where it was called was wrong, so it would be called even if the cached value was defined.  And it would return undefined if Unicode::UTF8 was unavailable, which would be rechecked each time.
