### PR TITLE
Prevent filehandle() (and anything which uses it) from clearing $@.

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -796,6 +796,7 @@ sub filehandle {
 
     unless ($fh) {
         my $mode = $opentype . $binmode;
+        local $@;
         open $fh, $mode, $self->[PATH] or $self->_throw("open ($mode)");
     }
 

--- a/t/filehandle.t
+++ b/t/filehandle.t
@@ -1,0 +1,17 @@
+use 5.008001;
+use strict;
+use warnings;
+use Test::More 0.96;
+
+use lib 't/lib';
+use TestUtils qw/exception/;
+
+use Path::Tiny;
+
+subtest q[filehandle encodings and $@] => sub {
+    local $@ = 'foo';
+    Path::Tiny->tempfile->filehandle( ">>", ":unix:encoding(UTF-8)" );
+    is $@, 'foo', 'a filehandle with encodings does not clear $@';
+};
+
+done_testing;


### PR DESCRIPTION
Getting a filehandle with an encoding will clear $@.  This is actually
a problem in Encode.  Encoding::Encoding::perlio_ok() has an
unprotected eval block.  But that's a core module outside of our
control.

This potentially affects all the *_utf8 methods.

This is particularly bad for append_utf8() because logging an error
will also delete the error.
