### PR TITLE
Hook for plugin system

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -14,7 +14,7 @@ use File::Spec 3.40 ();
 use Carp ();
 
 our @EXPORT    = qw/path/;
-our @EXPORT_OK = qw/cwd rootdir tempfile tempdir/;
+our @EXPORT_OK = qw/cwd rootdir tempfile tempdir path_plugins /;
 
 use constant {
     PATH     => 0,
@@ -363,6 +363,37 @@ sub _parse_file_temp_args {
         :                          ()
     );
     return ( \@template, \%args );
+}
+
+=construct path_plugins
+
+    path_plugins( '+Serialize', 'Some::Other::Plugin' );
+
+Injects the exported methods of the given plugin modules into
+C<Path::Tiny>. Names prefixed with a C<+> will be expanded to the
+C<Path::Tiny::*> namespace.
+
+Returns the name of all plugins currently used.
+
+=cut
+
+my %plugins;
+
+sub path_plugins {
+    my @plugins = @_;
+
+    # TODO what namespace we want for plugins,
+    # Path::Tiny::* or Path::Tiny::Plugin::* ?
+    s/^\+/Path::Tiny::/ for @plugins;
+
+    for my $plugin ( @plugins ) {
+        eval "use $plugin; 1" 
+            or die "couldn't use '$plugin': $@";
+        $plugin->import;
+        $plugins{$plugin} = 1;
+    }
+
+    return keys %plugins;
 }
 
 #--------------------------------------------------------------------------#

--- a/t/lib/Path/Tiny/Encrypt/ROT13.pm
+++ b/t/lib/Path/Tiny/Encrypt/ROT13.pm
@@ -1,0 +1,24 @@
+package Path::Tiny::Encrypt::ROT13;
+
+use parent 'Exporter';
+
+our @EXPORT = qw/ spew_rot13 slurp_rot13 /;
+
+sub spew_rot13 {
+    my( $self, @data ) = @_;
+
+    y/A-Za-z/N-ZA-Mn-za-m/ for @data;
+
+    $self->spew(@data);
+}
+
+sub slurp_rot13 {
+    my $self = shift;
+
+    my $content = $self->slurp;
+    $content =~ y/A-Za-z/N-ZA-Mn-za-m/;
+
+    return $content;
+}
+
+1;

--- a/t/plugins.t
+++ b/t/plugins.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+
+use Test::More tests => 3;
+
+use lib 't/lib';
+
+use Path::Tiny qw/ tempfile path_plugins /;
+
+is_deeply [ path_plugins( '+Encrypt::ROT13' ) ]
+            => [ 'Path::Tiny::Encrypt::ROT13' ], 'plugin loaded';
+
+# create the file
+my $message = "Hello world!";
+my $file  = tempfile();
+$file->spew_rot13($message);
+
+is $file->slurp => 'Uryyb jbeyq!', 'file is encrypted';
+
+is $file->slurp_rot13 => $message, 'we can decrypt it';


### PR DESCRIPTION
I added a 'path_plugins' function that is doing a very simple injection of exported functions of potential plugin modules.

The idea is to be able to add functionality to Path::Tiny without besmirching its 'Tiny' moniker. In the added test there is a frivolous example of a rot13 encrypter/decrypter, but I already have something a tad more serious at https://github.com/yanick/Path-Tiny-Serialize

TBD item: I've assumed the namespace of the plugins to be Path::Tiny::*, but you might perhaps
want to move that to Path::Tiny::Plugin::*.