### PR TITLE
Check if the return value is actually a scalar ref

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -1726,7 +1726,7 @@ sub visit {
     while ( my $file = $next->() ) {
         local $_ = $file;
         my $r = $cb->( $file, $state );
-        last if ref($r) && !$$r;
+        last if ref($r) eq 'SCALAR' && !$$r;
     }
     return $state;
 }

--- a/t/basic.t
+++ b/t/basic.t
@@ -172,6 +172,14 @@ is $file->parent,  '/foo/baz';
     };
     is( $err, '', "no exception if assertion succeeds" );
     isa_ok( $path, "Path::Tiny", "assertion return value" );
+
+    $err = exception {
+        path(".")->visit(
+            sub { $_[1]->{$_} = { path => $_ } },
+            { recurse => 1 },
+        );
+    };
+    is $err, "", 'no exception';
 }
 
 done_testing();


### PR DESCRIPTION
if visit callback stores a reference or object to $state, visit() will die with a cryptc `Not a SCALAR reference` error.