### PR TITLE
make visit() only react to SCALAR refs

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -1726,7 +1726,7 @@ sub visit {
     while ( my $file = $next->() ) {
         local $_ = $file;
         my $r = $cb->( $file, $state );
-        last if ref($r) && !$$r;
+        last if ref($r) eq 'SCALAR' && !$$r;
     }
     return $state;
 }

--- a/t/visit.t
+++ b/t/visit.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+
+use Test::More tests => 3;
+
+use Path::Tiny;
+
+path('t')->visit(sub{ return [ ] });
+
+pass "visit callback doesn't choke on random returned refs";
+
+my $all;
+my $terminated;
+
+path('t')->visit(sub{ $all++ });
+
+path('t')->visit(sub{ $terminated++; return \0 if $terminated == 10 });
+
+is $terminated => 10, "terminated before the whole dir was read";
+
+cmp_ok $all, '>=', $terminated, "we have more than 10 tests in that dir";
+


### PR DESCRIPTION
As the test was, it was assuming that any ref returned by the
callback was a SCALAR ref, which can trip code like

        # silly, but capture the spirit of the oopsie
        $path->visit(sub{
           $something = [ @$something, $_ ];
        })