### PR TITLE
copy() now returns the new copy

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -670,9 +670,11 @@ sub chmod {
 
     path("/tmp/foo.txt")->copy("/tmp/bar.txt");
 
-Copies a file using L<File::Copy>'s C<copy> function.
+Copies a file using L<File::Copy>'s C<copy> function. Upon
+success, returns the C<Path::Tiny> object for the newly copied
+file.
 
-Current API available since 0.001.
+Current API available since 0.070.
 
 =cut
 
@@ -682,6 +684,8 @@ sub copy {
     require File::Copy;
     File::Copy::copy( $self->[PATH], $dest )
       or Carp::croak("copy failed for $self to $dest: $!");
+
+    return -d $dest ? path( $dest, $self->basename ) : path($dest);
 }
 
 =method digest


### PR DESCRIPTION
Not terribly useful if the copy argument was already a file::tiny file, but can be handy if it was a string, or
a file::tiny dir.