### PR TITLE
Visit: only dereference scalar refs

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -1684,7 +1684,7 @@ and a hash reference to accumulate state as the second argument.  For example:
         sub {
             my ($path, $state) = @_;
             return if $path->is_dir;
-            $state{$path} = -s $path;
+            $state->{$path} = -s $path;
         },
         { recurse => 1 }
     );
@@ -1703,7 +1703,7 @@ stops all iteration and returns the state hash reference.
     my $files = path("/tmp")->visit(
         sub {
             my ($path, $state) = @_;
-            $state{$path}++ if -s $path > 102400
+            $state->{$path}++ if -s $path > 102400
             return \0 if keys %$state == 10;
         },
         { recurse => 1 }
@@ -1726,7 +1726,7 @@ sub visit {
     while ( my $file = $next->() ) {
         local $_ = $file;
         my $r = $cb->( $file, $state );
-        last if ref($r) && !$$r;
+        last if ref($r) eq 'SCALAR' && !$$r;
     }
     return $state;
 }

--- a/t/filesystem.t
+++ b/t/filesystem.t
@@ -151,6 +151,15 @@ my $tmpdir = Path::Tiny->tempdir;
         my ($file) = grep { $_ eq $dir->child('file.x') } @contents;
         ok $file;
         is -d $file, '';
+        
+        # Make sure non-scalar ref returns from callback
+        #  don't cause an error
+        ok($dir->visit(
+            sub {
+                my ($path, $state) = @_;
+                $state->{$path} = { key => 'value' };
+            }
+        ));
     };
 
     ok $dir->remove_tree;


### PR DESCRIPTION
Addresses issue #140, and added test.
Also fixes examples in visit method documentation ($state is a hashref, not a hash)