### PR TITLE
Fix incorrect Win32 tilde expansions

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -237,8 +237,8 @@ sub path {
     if ( $path =~ m{^(~[^/]*).*} ) {
         require File::Glob;
         my ($homedir) = File::Glob::bsd_glob($1);
+        $homedir =~ tr[\\][/] if IS_WIN32();
         $path =~ s{^(~[^/]*)}{$homedir};
-        $path =~ tr[\\][/] if IS_WIN32();
     }
 
     bless [ $path, $cpath ], __PACKAGE__;

--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -238,6 +238,7 @@ sub path {
         require File::Glob;
         my ($homedir) = File::Glob::bsd_glob($1);
         $path =~ s{^(~[^/]*)}{$homedir};
+        $path =~ tr[\\][/] if IS_WIN32();
     }
 
     bless [ $path, $cpath ], __PACKAGE__;

--- a/t/basic.t
+++ b/t/basic.t
@@ -6,6 +6,8 @@ use File::Spec;
 use Path::Tiny;
 use Cwd;
 
+my $IS_WIN32 = $^O eq 'MSWin32';
+
 use lib 't/lib';
 use TestUtils qw/exception/;
 
@@ -122,6 +124,7 @@ is $file->parent,  '/foo/baz';
 # tilde processing
 {
     my ($homedir) = glob('~');
+    $homedir =~ tr[\\][/] if $IS_WIN32;
     my $username = path($homedir)->basename;
     my ($root_homedir) = glob('~root');
     my ($missing_homedir) = glob('~idontthinkso');


### PR DESCRIPTION
* translate backslashes to slashes after glob expansion of tildes
* fixes #149
