### PR TITLE
Add "Edit file methods a la file slurp" (Issue #161)

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -1763,7 +1763,7 @@ sub volume {
     return $self->[VOL];
 }
 
-=method edit_raw, edit_utf8
+=method edit, edit_raw, edit_utf8
 
     path("/tmp/foo.txt")->edit_utf8(sub {
             s/string_to_replace/replacement/g;
@@ -1773,11 +1773,18 @@ sub volume {
             s/\A/FilePrefix/;
         });
 
+    path("/tmp/foo.bin")->edit(sub {
+            $_ .= "Suffix\n";
+        }, { binmode => ':raw'}
+        );
+
 These are convenience methods that allow "editing" the file by using
 a single callback (= read→modify→write). This slurps the file using
 slurp_utf8() or equivalent, places it inside the $_ variable, calls the
 callback given as a parameter, and then writes the new $_ (which will be
 mutated) back to the file.
+
+edit() also accepts the same arguments' hash reference as slurp() and spew().
 
 =cut
 
@@ -1797,6 +1804,17 @@ sub edit_raw {
     local $_ = $self->slurp_raw;
     $cb->();
     $self->spew_raw($_);
+
+    return;
+}
+
+sub edit
+{
+    my ($self, $cb, $args) = @_;
+
+    local $_ = $self->slurp($args);
+    $cb->();
+    $self->spew($args, $_);
 
     return;
 }

--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -1786,6 +1786,40 @@ sub edit_utf8 {
     return;
 }
 
+=method edit_lines_utf8
+
+    path("/tmp/foo.txt")->edit_lines_utf8(sub {
+        s/^/add_this_prefix_to_every_line = /;
+        });
+
+This is a convenience method that allows "editing" the file by using
+a single callback (= read→modify→write). This iterates over the files lines,
+places each line in $_, calls the callback and writes the modified $_ to
+the new version of the file.
+
+=cut
+
+sub edit_lines_utf8 {
+    my ($self, $cb) = @_;
+
+    my $in_fh = $self->openr_utf8;
+    my $temp_path = Path::Tiny->tempfile;
+    my $temp_fh = $temp_path->openw_utf8;
+
+    local $_;
+    while ($_ = <$in_fh>)
+    {
+        $cb->($_);
+        $temp_fh->print($_);
+    }
+    $temp_fh->close;
+    $in_fh->close;
+
+    $temp_path->move($self->[PATH]);
+
+    return;
+}
+
 package Path::Tiny::Error;
 
 our @CARP_NOT = qw/Path::Tiny/;

--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -1763,16 +1763,20 @@ sub volume {
     return $self->[VOL];
 }
 
-=method edit_utf8
+=method edit_raw, edit_utf8
 
     path("/tmp/foo.txt")->edit_utf8(sub {
             s/string_to_replace/replacement/g;
         });
 
-This is a convenience method that allows "editing" the file by using
+    path("/tmp/foo.txt")->edit_raw(sub {
+            s/\A/FilePrefix/;
+        });
+
+These are convenience methods that allow "editing" the file by using
 a single callback (= read→modify→write). This slurps the file using
-slurp_utf8() , places it inside the $_ variable calls the callback given
-as a parameter and then writes it back to the file.
+slurp_utf8() or equivalent, places it inside the $_ variable, calls the
+callback given as a parameter, and then writes it back to the file.
 
 =cut
 
@@ -1782,6 +1786,16 @@ sub edit_utf8 {
     local $_ = $self->slurp_utf8;
     $cb->($_);
     $self->spew_utf8($_);
+
+    return;
+}
+
+sub edit_raw {
+    my ($self, $cb) = @_;
+
+    local $_ = $self->slurp_raw;
+    $cb->($_);
+    $self->spew_raw($_);
 
     return;
 }

--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -1776,7 +1776,8 @@ sub volume {
 These are convenience methods that allow "editing" the file by using
 a single callback (= read→modify→write). This slurps the file using
 slurp_utf8() or equivalent, places it inside the $_ variable, calls the
-callback given as a parameter, and then writes it back to the file.
+callback given as a parameter, and then writes the new $_ (which will be
+mutated) back to the file.
 
 =cut
 
@@ -1784,7 +1785,7 @@ sub edit_utf8 {
     my ($self, $cb) = @_;
 
     local $_ = $self->slurp_utf8;
-    $cb->($_);
+    $cb->();
     $self->spew_utf8($_);
 
     return;
@@ -1794,7 +1795,7 @@ sub edit_raw {
     my ($self, $cb) = @_;
 
     local $_ = $self->slurp_raw;
-    $cb->($_);
+    $cb->();
     $self->spew_raw($_);
 
     return;
@@ -1808,8 +1809,8 @@ sub edit_raw {
 
 This is a convenience method that allows "editing" the file by using
 a single callback (= read→modify→write). This iterates over the files lines,
-places each line in $_, calls the callback and writes the modified $_ to
-the new version of the file.
+places each line in $_, calls the callback and writes the new (and potentially
+mutated) $_ to the new version of the file.
 
 =cut
 
@@ -1823,7 +1824,7 @@ sub edit_lines_utf8 {
     local $_;
     while ($_ = <$in_fh>)
     {
-        $cb->($_);
+        $cb->();
         $temp_fh->print($_);
     }
     $temp_fh->close;

--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -1763,6 +1763,29 @@ sub volume {
     return $self->[VOL];
 }
 
+=method edit_utf8
+
+    path("/tmp/foo.txt")->edit_utf8(sub {
+            s/string_to_replace/replacement/g;
+        });
+
+This is a convenience method that allows "editing" the file by using
+a single callback (= read→modify→write). This slurps the file using
+slurp_utf8() , places it inside the $_ variable calls the callback given
+as a parameter and then writes it back to the file.
+
+=cut
+
+sub edit_utf8 {
+    my ($self, $cb) = @_;
+
+    local $_ = $self->slurp_utf8;
+    $cb->($_);
+    $self->spew_utf8($_);
+
+    return;
+}
+
 package Path::Tiny::Error;
 
 our @CARP_NOT = qw/Path::Tiny/;

--- a/t/input_output.t
+++ b/t/input_output.t
@@ -538,7 +538,18 @@ subtest "edit_lines_raw" => sub {
     is(
         $file->slurp_raw,
         ("prefix = Foo\nprefix = Bar\nprefix = Baz\nprefix = Quux\n"),
-        "edit_lines_raw",
+        "edit_lines_utf8",
+    );
+};
+
+subtest "edit_lines" => sub {
+    my $file = Path::Tiny->tempfile;
+    $file->spew_raw("Foo\nBar\nBaz\nQuux\n");
+    $file->edit_lines(sub { s/a/[replacement]/; }, {binmode => ':raw'});
+    is(
+        $file->slurp_raw,
+        ("Foo\nB[replacement]r\nB[replacement]z\nQuux\n"),
+        "edit_lines",
     );
 };
 

--- a/t/input_output.t
+++ b/t/input_output.t
@@ -498,5 +498,24 @@ subtest "edit_utf8" => sub {
     );
 };
 
+subtest "edit_utf8 param" => sub {
+    my $file = Path::Tiny->tempfile;
+    $file->spew_utf8(_utf8_lines);
+    $file->edit_utf8(sub {
+        my $text = shift;
+        $text =~ s/\ALine/It's my line/;
+        $_ = $text;
+
+        return;
+    });
+    my $line3 = "\302\261\n";
+    utf8::decode($line3);
+    is(
+        $file->slurp_utf8,
+        ("It's my line1\r\nLine2\n$line3"),
+        "edit_utf8 callback param",
+    );
+};
+
 done_testing;
 # COPYRIGHT

--- a/t/input_output.t
+++ b/t/input_output.t
@@ -498,6 +498,17 @@ subtest "edit_utf8" => sub {
     );
 };
 
+subtest "edit_raw" => sub {
+    my $file = Path::Tiny->tempfile;
+    $file->spew_raw("Foo Bar\nClam Bar\n");
+    $file->edit_raw(sub { s/Bar/Mangle/; });
+    is(
+        $file->slurp_raw,
+        "Foo Mangle\nClam Bar\n",
+        "edit_raw",
+    );
+};
+
 subtest "edit_utf8 param" => sub {
     my $file = Path::Tiny->tempfile;
     $file->spew_utf8(_utf8_lines);

--- a/t/input_output.t
+++ b/t/input_output.t
@@ -509,6 +509,17 @@ subtest "edit_raw" => sub {
     );
 };
 
+subtest "edit" => sub {
+    my $file = Path::Tiny->tempfile;
+    $file->spew_raw("One line\nTwo lines\nThree lines\n");
+    $file->edit(sub { s/line/row/; }, {binmode => ':raw'},);
+    is(
+        $file->slurp_raw,
+        "One row\nTwo lines\nThree lines\n",
+        "edit() was successful.",
+    );
+};
+
 subtest "edit_lines_utf8" => sub {
     my $file = Path::Tiny->tempfile;
     $file->spew_utf8("Foo\nBar\nBaz\nQuux\n");

--- a/t/input_output.t
+++ b/t/input_output.t
@@ -531,5 +531,16 @@ subtest "edit_lines_utf8" => sub {
     );
 };
 
+subtest "edit_lines_raw" => sub {
+    my $file = Path::Tiny->tempfile;
+    $file->spew_raw("Foo\nBar\nBaz\nQuux\n");
+    $file->edit_lines_raw(sub { s/\A/prefix = /gm; });
+    is(
+        $file->slurp_raw,
+        ("prefix = Foo\nprefix = Bar\nprefix = Baz\nprefix = Quux\n"),
+        "edit_lines_raw",
+    );
+};
+
 done_testing;
 # COPYRIGHT

--- a/t/input_output.t
+++ b/t/input_output.t
@@ -485,5 +485,18 @@ subtest "openrw (raw)" => sub {
     is( $got, join( '', _lines ), "openr & read" );
 };
 
+subtest "edit_utf8" => sub {
+    my $file = Path::Tiny->tempfile;
+    $file->spew_utf8(_utf8_lines);
+    $file->edit_utf8(sub { s/^Line/Row/gm; });
+    my $line3 = "\302\261\n";
+    utf8::decode($line3);
+    is(
+        $file->slurp_utf8,
+        ("Row1\r\nRow2\n$line3"),
+        "edit_utf8",
+    );
+};
+
 done_testing;
 # COPYRIGHT

--- a/t/input_output.t
+++ b/t/input_output.t
@@ -517,5 +517,16 @@ subtest "edit_utf8 param" => sub {
     );
 };
 
+subtest "edit_lines_utf8" => sub {
+    my $file = Path::Tiny->tempfile;
+    $file->spew_utf8("Foo\nBar\nBaz\nQuux\n");
+    $file->edit_lines_utf8(sub { s/\A/prefix = /gm; });
+    is(
+        $file->slurp_utf8,
+        ("prefix = Foo\nprefix = Bar\nprefix = Baz\nprefix = Quux\n"),
+        "edit_lines_utf8",
+    );
+};
+
 done_testing;
 # COPYRIGHT

--- a/t/input_output.t
+++ b/t/input_output.t
@@ -509,25 +509,6 @@ subtest "edit_raw" => sub {
     );
 };
 
-subtest "edit_utf8 param" => sub {
-    my $file = Path::Tiny->tempfile;
-    $file->spew_utf8(_utf8_lines);
-    $file->edit_utf8(sub {
-        my $text = shift;
-        $text =~ s/\ALine/It's my line/;
-        $_ = $text;
-
-        return;
-    });
-    my $line3 = "\302\261\n";
-    utf8::decode($line3);
-    is(
-        $file->slurp_utf8,
-        ("It's my line1\r\nLine2\n$line3"),
-        "edit_utf8 callback param",
-    );
-};
-
 subtest "edit_lines_utf8" => sub {
     my $file = Path::Tiny->tempfile;
     $file->spew_utf8("Foo\nBar\nBaz\nQuux\n");


### PR DESCRIPTION
This pull req adds "Edit file methods" emulating File-Slurp or perl -pi as agreed on https://github.com/dagolden/Path-Tiny/issues/161 . Sorry it took me so long.