### PR TITLE
Support Test::More < 0.97_01

### DIFF
--- a/t/recurse.t
+++ b/t/recurse.t
@@ -139,15 +139,14 @@ subtest 'with symlinks' => sub {
             }
             is_deeply( [ sort @files ], [ sort @follow ], "Follow symlinks" )
               or diag explain \@files;
-          },
+          };
           subtest 'visit' => sub {
             my @files;
             path(".")
               ->visit( sub { push @files, "$_[0]" }, { recurse => 1, follow_symlinks => 1 }, );
             is_deeply( [ sort @files ], [ sort @follow ], "Follow symlinks" )
               or diag explain \@files;
-          },
-          ;
+          };
     };
 };
 


### PR DESCRIPTION
The prototype for subtest (in Test::More pre- 0.97_01) causes this test to error out, IE:

    [user@box Path-Tiny-0.076]# perl -Ilib t/recurse.t
    Too many arguments for Test::More::subtest at t/recurse.t line 149, near "};"
    Execution of t/recurse.t aborted due to compilation errors.