### PR TITLE
fix relative method with regex char in base path

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -1509,7 +1509,7 @@ sub relative {
     if ( $base->subsumes($self) ) {
         $base = "" if $base->is_rootdir;
         my $relative = "$self";
-        $relative =~ s{\A$base/}{};
+        $relative =~ s{\A\Q$base/}{};
         return path($relative);
     }
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -106,6 +106,9 @@ is $file->parent,  '/foo/baz';
 
     $file = path('one/two/three');
     is $file->relative('one'), 'two/three';
+
+    $file = path('/one[0/two');
+    is $file->relative( '/one[0' ), 'two', 'path with regex special char';
 }
 
 {


### PR DESCRIPTION
If the base path has a special regex character (like '[' for example),
the relative() method might die due to a bad regex, or it might simply
return the entire path, failing to remove the base path as desired.

Fixes preaction/Statocles#476

Next time I'll take your request for help testing more seriously, though I suspect this situation is rare indeed...