### PR TITLE
Doc fixes to copy() and move() methods

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -681,9 +681,9 @@ sub chmod {
 
     path("/tmp/foo.txt")->copy("/tmp/bar.txt");
 
-Copies a file using L<File::Copy>'s C<copy> function. Upon
-success, returns the C<Path::Tiny> object for the newly copied
-file.
+Copies the current path to the given destination using L<File::Copy>'s
+C<copy> function. Upon success, returns the C<Path::Tiny> object for the
+newly copied file.
 
 Current API available since 0.070.
 

--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -1256,7 +1256,9 @@ sub mkpath {
 
     path("foo.txt")->move("bar.txt");
 
-Just like C<rename>.
+Move the current path to the given destination path using Perl's
+built-in L<rename|perlfunc/rename> function. Returns the result
+of the C<rename> function.
 
 Current API available since 0.001.
 


### PR DESCRIPTION
This PR clarifies the `copy()` docs to better explain which path is going to be copied where. It also expands the `move()` docs to explain which `rename` it means, and the return value from `move`.