### PR TITLE
unfold arrays in spew_utf8 when Unicode::UTF8 is present

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -1792,7 +1792,15 @@ sub spew_raw { splice @_, 1, 0, { binmode => ":unix" }; goto &spew }
 sub spew_utf8 {
     if ( defined($HAS_UU) ? $HAS_UU : ( $HAS_UU = _check_UU() ) ) {
         my $self = shift;
-        spew( $self, { binmode => ":unix" }, map { Unicode::UTF8::encode_utf8($_) } @_ );
+        my @data;
+        foreach my $fragment (@_) {
+            if (ref $fragment eq 'ARRAY') {
+                push @data, map { Unicode::UTF8::encode_utf8($_) } @$fragment;
+            } else {
+                push @data, Unicode::UTF8::encode_utf8($fragment);
+            }
+        }
+        spew( $self, { binmode => ":unix" }, @data );
     }
     else {
         splice @_, 1, 0, { binmode => ":unix:encoding(UTF-8)" };


### PR DESCRIPTION
How I reproduced the problem:
$ perl -MPath::Tiny -E 'path("1.txt")->spew_utf8( [ qw( a b c ) ] );'; cat 1.txt; echo
ARRAY(0x17150c0)

This seems to be a bug because the documentation suggests spew_utf8 accepts arrayrefs:
https://metacpan.org/pod/Path::Tiny#spew-spew_raw-spew_utf8
`path("foo.txt")->spew(\@data);`

I'm using Path::Tiny 0.052 and Unicode::UTF8 0.59, both packaged with Ubuntu 14.04.

I've checked that: 1). the problem seems to be fixed with the patch applied; 2). the unit tests pass with the patch applied.

Please review the patch and accept it if it's OK.

Also, thank you for maintaining this module, it is very useful.