### PR TITLE
Use PerlIO::utf8_strict if available

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -36,6 +36,7 @@ MetaNoIndex.package = flock
 
 [RemovePrereqs]
 remove = Unicode::UTF8
+remove = PerlIO::utf8_strict
 remove = Path::Class
 remove = Test::FailWarnings
 remove = threads

--- a/t/input_output_no_PU_UU.t
+++ b/t/input_output_no_PU_UU.t
@@ -1,0 +1,16 @@
+use 5.008001;
+use strict;
+use warnings;
+use Test::More 0.96;
+
+# Tiny equivalent of Devel::Hide
+BEGIN {
+    $INC{'Unicode/UTF8.pm'}       = undef;
+    $INC{'PerlIO/utf8_strict.pm'} = undef;
+}
+
+note "Hiding Unicode::UTF8 and PerlIO::utf8_strict";
+
+do "t/input_output.t";
+
+# COPYRIGHT


### PR DESCRIPTION
This uses PerlIO::utf8_strict in place of :encoding(UTF-8) if
available.  Unicode::UTF8 is still preferred, however.

Closes #66.

