### PR TITLE
Support for MSYS2

### DIFF
--- a/t/filesystem.t
+++ b/t/filesystem.t
@@ -343,7 +343,7 @@ SKIP: {
     my $file   = $newtmp->child("foo.txt");
     my $link   = $newtmp->child("bar.txt");
     $file->spew("Hello World\n");
-    eval { symlink $file => $link };
+    eval { symlink $file => $link; die unless -l $link };
     skip "symlink unavailable", 1 if $@;
     ok( $link->lstat->size, "lstat" );
 

--- a/t/mkpath.t
+++ b/t/mkpath.t
@@ -21,7 +21,9 @@ if ( $^O ne 'MSWin32' ) {
     my $path2 = path($tempdir)->child("bar");
     ok( !-e $path2, "target directory not created yet" );
     ok( $path2->mkpath( { mode => 0700 } ), "mkpath on directory with mode" );
-    is( $path2->stat->mode & 0777, 0700, "correct mode" );
+    if ( $^O ne 'msys' ) {
+        is( $path2->stat->mode & 0777, 0700, "correct mode" );
+    }
     ok( -d $path2, "target directory created" );
 }
 

--- a/t/recurse.t
+++ b/t/recurse.t
@@ -68,8 +68,14 @@ subtest 'no symlinks' => sub {
 };
 
 subtest 'with symlinks' => sub {
-    plan skip_all => "No symlink support"
-      unless $Config{d_symlink};
+    {
+        my $newtmp = Path::Tiny->tempdir;
+        my $file   = $newtmp->child("foo.txt");
+        my $link   = $newtmp->child("bar.txt");
+        $file->spew("Hello World\n");
+        eval { symlink $file => $link; die unless -l $link };
+    }
+    plan skip_all => "No symlink support" if $@;
 
     my $wd = tempd;
 

--- a/t/rel-abs.t
+++ b/t/rel-abs.t
@@ -109,7 +109,7 @@ subtest "relative on absolute paths with symlinks" => sub {
     my $deep = $cwd->child("foo/bar/baz/bam/bim/buz/wiz/was/woz");
     $deep->mkpath();
 
-    eval { symlink "foo/bar/baz", "baz" };
+    eval { symlink "foo/bar/baz", "baz"; die unless -l "baz" };
     plan skip_all => "No symlink support"
       if $@;
 

--- a/t/symlinks.t
+++ b/t/symlinks.t
@@ -10,7 +10,15 @@ use Config;
 use Path::Tiny;
 use Cwd 'abs_path';
 
-plan skip_all => "No symlink support" unless $Config{d_symlink};
+{
+    my $newtmp = Path::Tiny->tempdir;
+    my $file   = $newtmp->child("foo.txt");
+    my $link   = $newtmp->child("bar.txt");
+    $file->spew("Hello World\n");
+    eval { symlink $file => $link; die unless -l $link };
+}
+
+plan skip_all => "No symlink support" if $@;
 
 subtest "relative symlinks with updir" => sub {
     my $temp = Path::Tiny->tempdir;


### PR DESCRIPTION
The Perl that comes with MSYS2 is similar to cygwin, but with some weirdisms.

 1. File mode is not reliable; I felt justified in skipping that test since it would be skipped on MSWin32 already.
 2. MSYS2 does not have symlinks, but provides an interface that copies files when you attempt to sym or hardlink a file.  See the comment on the second commit for details.

It would be useful to be able to use `Path::Tiny` on MSYS2, but I can see an argument for this being a slightly borked Perl too, so might be able to follow up with the MSYS2 folks.  My preference would be to fix it here though.