### PR TITLE
partial support for MSYS2

### DIFF
--- a/t/filesystem.t
+++ b/t/filesystem.t
@@ -4,6 +4,7 @@ use warnings;
 use Test::More 0.96;
 use File::Temp qw(tmpnam tempdir);
 use File::Spec;
+use Config;
 use Cwd;
 
 use lib 't/lib';
@@ -344,7 +345,7 @@ SKIP: {
     my $link   = $newtmp->child("bar.txt");
     $file->spew("Hello World\n");
     eval { symlink $file => $link };
-    skip "symlink unavailable", 1 if $@;
+    skip "symlink unavailable", 1 unless $Config{d_symlink};
     ok( $link->lstat->size, "lstat" );
 
     is( $link->realpath, $file->realpath, "realpath resolves symlinks" );

--- a/t/mkpath.t
+++ b/t/mkpath.t
@@ -21,7 +21,9 @@ if ( $^O ne 'MSWin32' ) {
     my $path2 = path($tempdir)->child("bar");
     ok( !-e $path2, "target directory not created yet" );
     ok( $path2->mkpath( { mode => 0700 } ), "mkpath on directory with mode" );
-    is( $path2->stat->mode & 0777, 0700, "correct mode" );
+    if ( $^O ne 'msys' ) {
+        is( $path2->stat->mode & 0777, 0700, "correct mode" );
+    }
     ok( -d $path2, "target directory created" );
 }
 

--- a/t/rel-abs.t
+++ b/t/rel-abs.t
@@ -2,6 +2,7 @@ use 5.008001;
 use strict;
 use warnings;
 use Test::More 0.96;
+use Config;
 
 use lib 't/lib';
 use TestUtils qw/exception pushd tempd/;
@@ -109,9 +110,8 @@ subtest "relative on absolute paths with symlinks" => sub {
     my $deep = $cwd->child("foo/bar/baz/bam/bim/buz/wiz/was/woz");
     $deep->mkpath();
 
-    eval { symlink "foo/bar/baz", "baz" };
     plan skip_all => "No symlink support"
-      if $@;
+      unless $Config{d_symlink};
 
     my ( $path, $base, $expect );
 


### PR DESCRIPTION
I don't think you had an objection to the first commit, and since you indicated a preference for $Config{d_symlink}, please consider this alternative which at least makes the symlink tests consistent.  It should make it potentially easier to fix on the MSYS2 side to fix one thing instead of two.