### PR TITLE
Add Digest::MD5 test dependency

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -51,6 +51,9 @@ Digest::SHA = 5.45
 File::Path = 2.07
 File::Temp = 0.19 ; newdir
 
+[Prereqs / TestRequires]
+Digest::MD5 = 0
+
 [Prereqs / Recommends]
 Unicode::UTF8 = 0.58
 


### PR DESCRIPTION
t/digest.t requires Digest::MD5 indirectly