### PR TITLE
show errors from tests run via do

### DIFF
--- a/t/input_output.t
+++ b/t/input_output.t
@@ -552,4 +552,6 @@ subtest "edit_lines" => sub {
 };
 
 done_testing;
+
+1;
 # COPYRIGHT

--- a/t/input_output_no_PU_UU.t
+++ b/t/input_output_no_PU_UU.t
@@ -11,6 +11,6 @@ use lib map {
 
 note "Hiding Unicode::UTF8 and PerlIO::utf8_strict";
 
-do "./t/input_output.t";
+do "./t/input_output.t" or die $@ || $!;
 
 # COPYRIGHT

--- a/t/input_output_no_UU.t
+++ b/t/input_output_no_UU.t
@@ -12,6 +12,6 @@ use lib map {
 
 note "Hiding Unicode::UTF8";
 
-do "./t/input_output.t";
+do "./t/input_output.t" or die $@ || $!;
 
 # COPYRIGHT


### PR DESCRIPTION
Two of the test scripts run t/input_output.t using do.  That test script
may fail with an exception, so the do calls should check for this and
rethrow the error.  Ensure t/input_output.t returns a true value so the
check can be reliable.