### PR TITLE
Added 'process*' methods

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@ Revision history for Path-Tiny
 
 {{$NEXT}}
 
+    [Additions]
+    
+    - Added 'process' method to execute a callback for each line of a
+      file without really editing it.
+
 0.104     2017-02-17 07:17:00-05:00 America/New_York
 
     - No changes from 0.103-TRIAL.

--- a/t/input_output.t
+++ b/t/input_output.t
@@ -551,5 +551,30 @@ subtest "edit_lines" => sub {
         "edit_lines", );
 };
 
+subtest "process_lines_utf8" => sub {
+    my $file = Path::Tiny->tempfile;
+    $file->spew_utf8("Foo\nBar\nBaz\nQuux\n");
+    my $counter = 0;
+    $file->process_lines_utf8( sub { $counter++ if m/\AB/; } );
+    is( $counter, 2, "process_lines_utf8" );
+};
+
+subtest "process_lines_raw" => sub {
+    my $file = Path::Tiny->tempfile;
+    $file->spew_raw("Foo\nBar\nBaz\nQuux\n");
+    my $counter = 0;
+    $file->process_lines_raw( sub { $counter++ if m/\AB/; } );
+    is( $counter, 2, "process_lines_utf8" );
+};
+
+subtest "process_lines" => sub {
+    my $file = Path::Tiny->tempfile;
+    $file->spew_raw("Foo\nBar\nBaz\nQuux\n");
+    my $counter = 0;
+    $file->process_lines_raw( sub { $counter++ if m/\AB/; } );
+    is( $counter, 2, "process_lines_utf8" );
+};
+
+
 done_testing;
 # COPYRIGHT


### PR DESCRIPTION
Hi, David

Not sure if you are interested in this method. But I may confess I would have used it already some times if it existed. The rationale is: what to process a file, line by line, but do not want to edit it, as it is (for example) read-only. 

If you find this useful, I would be grateful.

If you think something is missing, let me know, and I will fix it.

Cheers
ambs