### PR TITLE
prevent outer $SIG{__DIE__} handler from being called when probing for the existance of optional modules

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -40,13 +40,23 @@ sub THAW   { return path( $_[2] ) }
 my $HAS_UU; # has Unicode::UTF8; lazily populated
 
 sub _check_UU {
-    !!eval { require Unicode::UTF8; Unicode::UTF8->VERSION(0.58); 1 };
+    !!eval {
+        local $SIG{__DIE__}; # prevent outer handler from being called
+        require Unicode::UTF8;
+        Unicode::UTF8->VERSION(0.58);
+        1;
+    };
 }
 
 my $HAS_PU; # has PerlIO::utf8_strict; lazily populated
 
 sub _check_PU {
-    !!eval { require PerlIO::utf8_strict; PerlIO::utf8_strict->VERSION(0.003); 1 };
+    !!eval {
+        local $SIG{__DIE__}; # prevent outer handler from being called
+        require PerlIO::utf8_strict;
+        PerlIO::utf8_strict->VERSION(0.003);
+        1;
+    };
 }
 
 my $HAS_FLOCK = $Config{d_flock} || $Config{d_fcntl_can_lock} || $Config{d_lockf};

--- a/t/fakelib/PerlIO/utf8_strict.pm
+++ b/t/fakelib/PerlIO/utf8_strict.pm
@@ -1,0 +1,3 @@
+package PerlIO::utf8_strict;
+
+0;    # make require fail

--- a/t/fakelib/Unicode/UTF8.pm
+++ b/t/fakelib/Unicode/UTF8.pm
@@ -1,0 +1,3 @@
+package Unicode::UTF8;
+
+0;    # make require fail

--- a/t/sig_die.t
+++ b/t/sig_die.t
@@ -25,4 +25,6 @@ $file->slurp_utf8;
 
 ok !$called_handler, 'outer $SIG{__DIE__} handler called';
 
+unlink $file;
+
 done_testing;

--- a/t/sig_die.t
+++ b/t/sig_die.t
@@ -1,0 +1,28 @@
+use 5.008001;
+use strict;
+use warnings;
+use Test::More 0.96;
+use File::Temp qw(tmpnam);
+
+use Path::Tiny;
+
+use lib 't/fakelib';
+
+my $file = path( scalar tmpnam() );
+ok $file, 'Got a filename via tmpnam()';
+
+{
+    my $fh = $file->openw;
+    ok $fh, "Opened $file for writing";
+
+    ok print( $fh "Foo\n" ), "Printed to $file";
+}
+
+my $called_handler;
+$SIG{__DIE__} = sub { ++$called_handler };
+
+$file->slurp_utf8;
+
+ok !$called_handler, 'outer $SIG{__DIE__} handler called';
+
+done_testing;


### PR DESCRIPTION
Using `->slurp_utf8()` aborted the execution of my script via its `$SIG{__DIE__}` handler, which was called by the `eval` in `_check_UU()`, because I do not have Unicode::UTF8 installed.

This patch prevents outer `$SIG{__DIE__}` handlers from being called using the workaround described in the documentation to `eval`.