### PR TITLE
Allow tempdir/tempfile as instance methods

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -390,7 +390,8 @@ Current API available since 0.097.
 =cut
 
 sub tempfile {
-    my ( $opts, $maybe_template, $args ) = _parse_file_temp_args(@_);
+    my ( $opts, $maybe_template, $args )
+        = _parse_file_temp_args(tempfile => @_);
 
     # File::Temp->new demands TEMPLATE
     $args->{TEMPLATE} = $maybe_template->[0] if @$maybe_template;
@@ -404,7 +405,8 @@ sub tempfile {
 }
 
 sub tempdir {
-    my ( $opts, $maybe_template, $args ) = _parse_file_temp_args(@_);
+    my ( $opts, $maybe_template, $args )
+        = _parse_file_temp_args(tempdir => @_);
 
     require File::Temp;
     my $temp = File::Temp->newdir( @$maybe_template, TMPDIR => 1, %$args );
@@ -419,12 +421,11 @@ sub tempdir {
 
 # normalize the various ways File::Temp does templates
 sub _parse_file_temp_args {
+    my $called_as = shift;
     if ( @_ && $_[0] eq 'Path::Tiny' ) { shift } # class method
     elsif ( @_ && eval{$_[0]->isa('Path::Tiny')} ) {
         my $dir = shift;
         if (! $dir->is_dir) {
-            my ( undef, undef, undef, $called_as ) = caller(1);
-            $called_as =~ s{^.*::}{};
             $dir->_throw( $called_as, $dir, "is not a directory object" );
         }
         push @_, DIR => $dir->stringify; # no overriding

--- a/t/temp.t
+++ b/t/temp.t
@@ -84,7 +84,7 @@ subtest "tempdir w/ leading template as instance method" => sub {
     my $repodir = $basedir->child('whatever');
     $repodir->remove_tree if $repodir->exists;
     $repodir->mkpath;
-    my $tempdir = $repodir->tempdir( TEMPLATE => "helloXXXXX" );
+    my $tempdir = $repodir->tempdir("helloXXXXX");
     like( $tempdir, qr/hello/, "found template" );
     ok( scalar($repodir->children) > 0, 'something was created' );
     my $basename = $tempdir->basename;
@@ -105,7 +105,7 @@ subtest "tempdir w/ leading template as instance method" => sub {
     ok( -d $repodir->child($basename), "right directory exists" );
 };
 
-subtest "tempfile w/ leading template as instance method" => sub {
+subtest "tempfile w/out leading template as instance method" => sub {
     my $wd = tempd;
 
     my $basedir = Path::Tiny->cwd;
@@ -126,7 +126,7 @@ subtest "tempfile w/out leading template as instance method" => sub {
     my $repodir = $basedir->child('whatever');
     $repodir->remove_tree if $repodir->exists;
     $repodir->mkpath;
-    my $tempfile = $repodir->tempfile("helloXXXXX");
+    my $tempfile = $repodir->tempfile( TEMPLATE => "helloXXXXX");
     like( $tempfile, qr/hello/, "found template" );
     ok( scalar($repodir->children) > 0, 'something was created' );
     my $basename = $tempfile->basename;

--- a/t/temp.t
+++ b/t/temp.t
@@ -140,8 +140,9 @@ subtest "tempfile, instance method, overridden DIR" => sub {
     my $repodir = $basedir->child('whatever');
     $repodir->remove_tree if $repodir->exists;
     $repodir->mkpath;
-    my $tempfile = $repodir->tempfile("helloXXXXX", DIR => '/');
-    ok( $tempfile->parent ne '/' ), "DIR is overridden";
+    my $bd = $basedir->stringify;
+    my $tempfile = $repodir->tempfile("helloXXXXX", DIR => $bd);
+    ok( $tempfile->parent ne $bd ), "DIR is overridden";
 };
 
 done_testing;

--- a/t/temp.t
+++ b/t/temp.t
@@ -77,5 +77,72 @@ subtest "cached_temp on non tempfile" => sub {
     like( $@, qr/has no cached File::Temp object/, "cached_temp error message" );
 };
 
+subtest "tempdir w/ leading template as instance method" => sub {
+    my $wd = tempd;
+
+    my $basedir = Path::Tiny->cwd;
+    my $repodir = $basedir->child('whatever');
+    $repodir->remove_tree if $repodir->exists;
+    $repodir->mkpath;
+    my $tempdir = $repodir->tempdir( TEMPLATE => "helloXXXXX" );
+    like( $tempdir, qr/hello/, "found template" );
+    ok( scalar($repodir->children) > 0, 'something was created' );
+    my $basename = $tempdir->basename;
+    ok( -d $repodir->child($basename), "right directory exists" );
+};
+
+subtest "tempdir w/ leading template as instance method" => sub {
+    my $wd = tempd;
+
+    my $basedir = Path::Tiny->cwd;
+    my $repodir = $basedir->child('whatever');
+    $repodir->remove_tree if $repodir->exists;
+    $repodir->mkpath;
+    my $tempdir = $repodir->tempdir("helloXXXXX");
+    like( $tempdir, qr/hello/, "found template" );
+    ok( scalar($repodir->children) > 0, 'something was created' );
+    my $basename = $tempdir->basename;
+    ok( -d $repodir->child($basename), "right directory exists" );
+};
+
+subtest "tempfile w/ leading template as instance method" => sub {
+    my $wd = tempd;
+
+    my $basedir = Path::Tiny->cwd;
+    my $repodir = $basedir->child('whatever');
+    $repodir->remove_tree if $repodir->exists;
+    $repodir->mkpath;
+    my $tempfile = $repodir->tempfile( TEMPLATE => "helloXXXXX" );
+    like( $tempfile, qr/hello/, "found template" );
+    ok( scalar($repodir->children) > 0, 'something was created' );
+    my $basename = $tempfile->basename;
+    ok( -e $repodir->child($basename), "right file exists" );
+};
+
+subtest "tempfile w/out leading template as instance method" => sub {
+    my $wd = tempd;
+
+    my $basedir = Path::Tiny->cwd;
+    my $repodir = $basedir->child('whatever');
+    $repodir->remove_tree if $repodir->exists;
+    $repodir->mkpath;
+    my $tempfile = $repodir->tempfile("helloXXXXX");
+    like( $tempfile, qr/hello/, "found template" );
+    ok( scalar($repodir->children) > 0, 'something was created' );
+    my $basename = $tempfile->basename;
+    ok( -e $repodir->child($basename), "right file exists" );
+};
+
+subtest "tempfile, instance method, overridden DIR" => sub {
+    my $wd = tempd;
+
+    my $basedir = Path::Tiny->cwd;
+    my $repodir = $basedir->child('whatever');
+    $repodir->remove_tree if $repodir->exists;
+    $repodir->mkpath;
+    my $tempfile = $repodir->tempfile("helloXXXXX", DIR => '/');
+    ok( $tempfile->parent ne '/' ), "DIR is overridden";
+};
+
 done_testing;
 # COPYRIGHT


### PR DESCRIPTION
This patch allows using methods tempdir/tempfile as instance methods too, in addition to class methods and simple functions.

When used as instance methods, the underlying instance MUST represent a directory. In this case, it is used to override the DIR option of File::Temp.

The documentation makes a reference to the version when the added behavior is made available, I don't know if this wanted.

This pull request addresses #115 