### PR TITLE
Add size() and human_size() methods to Path::Tiny

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -1772,12 +1772,34 @@ sub sibling {
     return path( $self->parent->[PATH], @_ );
 }
 
+=method size
+
+    $bytes = path("/tmp/foo.txt")->size; # 2831
+
+Returns the file size in bytes of the C<Path::Tiny> object, or C<undef> if the
+file does not exist.
+
+B<NOTE>: This is a wrapper around the built-in C<-s> method, and is intended to
+increase code readability.
+
+=cut
+
 sub size {
     my $self  = shift();
     my $bytes = -s $self->[PATH];
 
     return $bytes;
 }
+
+=method human_size
+
+    $str = path("/tmp/foo.txt")->human_size; # 2.8k
+    $str = path("/tmp/big.iso")->human_size; # 4.6g
+
+Returns the file size of the C<Path::Tiny> object in a B<human readable> string,
+or C<undef> if the file does not exist.
+
+=cut
 
 sub human_size {
     my $self = shift();

--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -1772,6 +1772,38 @@ sub sibling {
     return path( $self->parent->[PATH], @_ );
 }
 
+sub size {
+    my $self  = shift();
+    my $bytes = -s $self->[PATH];
+
+    return $bytes;
+}
+
+sub human_size {
+    my $self = shift();
+    my $size = $self->size();
+
+    if (!defined $size) {
+        return undef;
+    }
+
+    if ($size > 1024**5) {
+        $size = sprintf("%.1fP", $size / 1024**5);
+    } elsif ($size > 1024**4) {
+        $size = sprintf("%.1fT", $size / 1024**4);
+    } elsif ($size > 1024**3) {
+        $size = sprintf("%.1fG", $size / 1024**3);
+    } elsif ($size > 1024**2) {
+        $size = sprintf("%.1fM", $size / 1024**2);
+    } elsif ($size > 1024) {
+        $size = sprintf("%.1fK", $size / 1024);
+    } elsif ($size >= 0) {
+        $size = sprintf("%dB", $size);
+    }
+
+    return $size;
+}
+
 =method slurp, slurp_raw, slurp_utf8
 
     $data = path("foo.txt")->slurp;


### PR DESCRIPTION
A really common workflow I run in to is needing to know the size of a file in a human readable way. I've always included [this function](https://www.perturb.org/display/810_Perlfunc_human_size.html) in my code, but I think it bears including in `Path::Tiny` itself as well. This pull-request adds two new methods: `size()` and `human_size()`

    $bytes = path("/tmp/foo.txt")->size; # 2831

    $str = path("/tmp/foo.txt")->human_size; # 2.8k
    $str = path("/tmp/big.iso")->human_size; # 4.6g

It also should behave appropriately for non-existent files (return `undef`).