### PR TITLE
Drop trailling dotstar from tilde match

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -244,7 +244,7 @@ sub path {
         $path .= ( _is_root($path) ? "" : "/" ) . join( "/", @_ );
     }
 
-    my ($tilde) = $path =~ m{^(~[^/]*).*};
+    my ($tilde) = $path =~ m{^(~[^/]*)};
 
     # canonicalize, but with unix slashes and put back trailing volume slash
     my $cpath = $path = File::Spec->canonpath($path);


### PR DESCRIPTION
I didn’t pay attention to this when I wrote #191.

A `.*` at the end of a pattern does not affect in any way where or what the pattern matches. All it does is waste a few CPU cycles.