### PR TITLE
Fix tilde expansion bug in FREEZE/THAW

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -27,13 +27,13 @@ use constant {
 };
 
 use overload (
-    q{""}    => sub    { $_[0]->[PATH] },
+    q{""}    => 'stringify',
     bool     => sub () { 1 },
     fallback => 1,
 );
 
 # FREEZE/THAW per Sereal/CBOR/Types::Serialiser protocol
-sub FREEZE { return $_[0]->[PATH] }
+*FREEZE = \&stringify;
 sub THAW   { return path( $_[2] ) }
 { no warnings 'once'; *TO_JSON = *FREEZE };
 
@@ -2188,7 +2188,7 @@ Current API available since 0.001.
 
 =cut
 
-sub stringify { $_[0]->[PATH] }
+sub stringify { $_[0]->[PATH] =~ /^~/ ? './' . $_[0]->[PATH] : $_[0]->[PATH] }
 
 =method subsumes
 


### PR DESCRIPTION
The new, much cleaner design for tilde expansion still leaves a trap for users who stringify a PT object and then later feed the result back to `path()`:

````
$ perl -Ilib -MPath::Tiny -le 'print path path("./~") . ""'
/home/ap
````

The special case back in #191 was meant to fix not just issues during internal processing, it also helped with round-tripping paths that travel part of their way through user code as strings. In the split-up of `path()` in fe8583b68f7d76b763613c29fedce26675e696f7 this was dropped.

In my opinion it should be reinstated.

Of course in this new cleaner design, where the internal path is always literal, the responsibility for this escaping ought to be relocated. Just as tilde expansion was relocated to the edge – on the way in –, so tilde escaping ought to be relocated to the edge – on the way out.

In fact, there is one place where it *must* happen on the way out: the `THAW` method still calls `path()`, *not* `_path()` – as it has to! Because only this way can instances of previous versions of PT be thawed correctly. But currently the `FREEZE` method just spits out the raw internal path with no tilde escaping. So this pair of methods still has a tilde expansion bug! And for backcompat this cannot be fixed by changing `THAW` – therefore it must be fixed by changing `FREEZE`.

And IMO, this same benefit ought to be afforded to user code.

Therefore this PR adds tilde escaping to the `stringify` method; and then it changes the `""` overload to `'stringify'` as well as aliases `FREEZE` to `stringify` so as to keep things DRY.