### PR TITLE
Test stringification thoroughly

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -166,13 +166,17 @@ is $file->parent,  '/foo/baz';
     for my $test (@tests) {
         my $path = path($test->[0]);
         my $internal_path = $path->[0]; # Avoid stringification adding a "./" prefix
-        is($internal_path, defined $test->[1] ? $test->[1] : $test->[0], $test->[2]);
+        my $expected = defined $test->[1] ? $test->[1] : $test->[0];
+        is($internal_path, $expected, $test->[2]);
+        is($path, $expected =~ /^~/ ? "./$expected" : $expected, '... and its stringification');
     }
 
-    is(path('.')->child('~')->[0], '~', 'Test indirect forms of literal tilde under current directory');
+    is(path('.')->child('~')->[0], '~', 'Test indirect form of literal tilde under current directory');
+    is(path('.')->child('~'), './~', '... and its stringification');
 
     $file = path('/tmp/foo/~root');
     is $file->relative('/tmp/foo')->[0], '~root', 'relative path begins with tilde';
+    is $file->relative('/tmp/foo'), "./~root", '... and its stringification is escaped';
 }
 
 # freeze/thaw

--- a/t/children.t
+++ b/t/children.t
@@ -41,7 +41,7 @@ like $@, qr/Invalid argument '\Q$arrayref\E' for children()/,
 
 my $raw_tilde = path(".", "~");
 my $tilde_child = $raw_tilde->child("rhubarb");
-is( $tilde_child->[0], "~/rhubarb", "child of literal tilde" );
+is( $tilde_child, "./~/rhubarb", "child of literal tilde" );
 
 done_testing;
 # COPYRIGHT


### PR DESCRIPTION
The only remark I have here is that I decided to just change the test in `t/children.t` because I thought that while it’s reasonable to test that both the internal path and its stringification are correct in all related tests in `t/basic.t`, once that is established, it doesn’t make sense to keep on testing this in every single test case everywhere.