### PR TITLE
Don't test symlink directories with absolute targets on MSWin32

### DIFF
--- a/t/filesystem.t
+++ b/t/filesystem.t
@@ -418,9 +418,11 @@ SKIP: {
     skip "symlink unavailable", 1 unless has_symlinks();
     eval { symlink $file => $link };
     ok( $link->lstat->size, "lstat" );
-
-    is( $link->realpath, $file->realpath, "realpath resolves symlinks" );
-
+    SKIP: {
+        skip "realpath of symlink not working correctly on Windows for perl <= 5.37.5"
+           if $^O eq "MSWin32" and "$]" <= 5.037005;
+        is( $link->realpath, $file->realpath, "realpath resolves symlinks" );
+    }
     ok $link->remove, 'remove symbolic link';
     ok $file->remove;
 

--- a/t/filesystem.t
+++ b/t/filesystem.t
@@ -417,7 +417,12 @@ SKIP: {
     $file->spew("Hello World\n");
     skip "symlink unavailable", 1 unless has_symlinks();
     eval { symlink $file => $link };
-    ok( $link->lstat->size, "lstat" );
+    if ($^O eq "MSWin32") {
+        ok( $link->lstat->size == 0, "lstat->size returns zero on Windows" );
+    }
+    else {
+        ok( $link->lstat->size, "lstat->size returns nonzero" );
+    }
     SKIP: {
         skip "realpath of symlink not working correctly on Windows for perl <= 5.37.5"
            if $^O eq "MSWin32" and "$]" <= 5.037005;

--- a/t/recurse.t
+++ b/t/recurse.t
@@ -107,7 +107,13 @@ subtest 'with symlinks' => sub {
 
     path($_)->touchpath for @tree;
 
-    symlink path( 'cccc', 'eeee' ), path('pppp');
+    if ($^O eq "MSWin32") {
+      # need to use backward slashes in relative symlink target on MSWin32
+      symlink 'cccc\eeee', path('pppp');
+    }
+    else {
+      symlink path( 'cccc', 'eeee' ), path('pppp');
+    }
     symlink path('aaaa.txt'), path('qqqq.txt');
 
     subtest 'no follow' => sub {

--- a/t/rel-abs.t
+++ b/t/rel-abs.t
@@ -111,7 +111,8 @@ subtest "relative on absolute paths with symlinks" => sub {
 
     plan skip_all => "No symlink support"
       unless has_symlinks();
-
+    plan skip_all => "Absolute paths in symlink directory targets not working on MSWin32 for perl<5.38"
+      if $^O eq "MSWin32" and "$]" < 5.038000;
     my ( $path, $base, $expect );
 
     # (a) symlink in common path

--- a/t/symlinks.t
+++ b/t/symlinks.t
@@ -19,12 +19,16 @@ subtest "relative symlinks with updir" => sub {
     my $foo = $td->child(qw/tmp foo/)->touch;
     my $bar = $td->child(qw/tmp tmp2 bar/);
 
-    symlink "../foo", $bar or die "Failed to symlink: $!\n";
+    my $relpath = "../foo";
+    # Account for a bug in Win32 API, see https://github.com/Perl/perl5/issues/20506
+    #  for more information
+    $relpath = "..\\foo" if $^O eq "MSWin32";
+    symlink $relpath, $bar or die "Failed to symlink: $!\n";
 
     ok -f $foo, "it's a file";
     ok -l $bar, "it's a link";
 
-    is readlink $bar, "../foo", "the link seems right";
+    is readlink $bar, $relpath, "the link seems right";
     is abs_path($bar), $foo, "abs_path gets's it right";
 
     is $bar->realpath, $foo, "realpath get's it right";


### PR DESCRIPTION
For more information see issue #277.

This fixes issue #277.

Note that this PR includes #268, #270, #272, and #274, which should be merged first.