### PR TITLE
Add ability to limit return from line to those lines matching a regexp

### DIFF
--- a/t/filesystem.t
+++ b/t/filesystem.t
@@ -31,7 +31,7 @@ if ( -e "/dev/null" ) {
 }
 
 my ( $volume, $dirname, $basename ) =
-  map { s{\\}{/}; $_ } File::Spec->splitpath($file);
+  map { s{\\}{/}; $_ } File::Spec->splitpath($file); ## no critic
 is( $file->volume,   $volume,   "volume correct" );
 is( $file->volume,   $volume,   "volume cached " );  # for coverage
 is( $file->dirname,  $dirname,  "dirname correct" );
@@ -201,6 +201,12 @@ my $tmpdir = Path::Tiny->tempdir;
 
     @content = $file->lines( { chomp => 1 } );
     is_deeply \@content, [ "Line1", "Line2" ];
+
+    @content = $file->lines( { pattern => qr/Line1/ } );
+    is_deeply \@content, [ "Line1\n" ];
+
+    @content = $file->lines( { chomp => 1, pattern => qr/Line1/ } );
+    is_deeply \@content, [ "Line1" ];
 
     ok( $file->remove, "removing file" );
     ok !-e $file, "file is gone";


### PR DESCRIPTION
This pull request is a result of me recognizing that I often apply a regexp to the results returned from path->lines.  The code to do this is simple so it doesn't require much effort to do. But, I continued to think of how much I would like to just specify that pattern in an argument to lines.  This is very similar to the use of pattern in Path::Iterator::Rule.  As such, I decide to submit a pull request that does just that.

This pull request contains the code, test and documentation additions to support filtering the return from the path->lines to only those lines matching a regexp specified in an argument name pattern (i.e. path->lines( pattern => qr/Line1/ ).

To accomplish this, I added _regexify and supporting methods from Path::Iterator::Rule.  All changes to required are local to the lines, lines_raw and lines_utf8 methods.

I have modified the embedded perldoc to reflect the addition of an argument name pattern.  The changes specify that the argument count will be applied before the pattern is applied.

Insofar as test are concerned, I have copied every existing test for lines and added pattern to it to insure that all test cases work properly.

If you decide that this functionality is desired, please let me know if you see any problems or want me to make any changes.  

Thank you for your consideration.

Lastly, I initially wanted to add this functionality to the slurp methods.  I decided to not include that in a pull request because of not being able to determine exactly how line endings should be delivered in the result. I'm open to working that in a separate pull request if you are interested.