### PR TITLE
Calling file relative path creation using scalar references.

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -243,7 +243,6 @@ sub path {
         my @frame;
         while(@frame=caller($i++)){
             last if $frame[1] ne __FILE__;
-            @frame=caller $i++;
         }
         
         my $p;

--- a/t/file_relative.t
+++ b/t/file_relative.t
@@ -7,16 +7,17 @@ use File::Glob;
 use Path::Tiny;
 use Cwd;
 
-my $IS_WIN32 = $^O eq 'MSWin32';
-my $IS_CYGWIN = $^O eq 'cygwin';
-
 use lib 't/lib';
 use TestUtils qw/exception/;
-
 
 my $file1 = path(\'foo.txt');
 isa_ok( $file1, "Path::Tiny" );
 
 ok "$file1" eq "t/foo.txt", "Caller relative via ref";
+
+my $file2 =Path::Tiny->new(\'foo.txt');
+isa_ok( $file2, "Path::Tiny" );
+
+ok "$file2" eq "t/foo.txt", "Caller relative via ref (from constructor)";
 
 done_testing();

--- a/t/file_relative.t
+++ b/t/file_relative.t
@@ -1,0 +1,22 @@
+use 5.008001;
+use strict;
+use warnings;
+use Test::More 0.96;
+use File::Spec;
+use File::Glob;
+use Path::Tiny;
+use Cwd;
+
+my $IS_WIN32 = $^O eq 'MSWin32';
+my $IS_CYGWIN = $^O eq 'cygwin';
+
+use lib 't/lib';
+use TestUtils qw/exception/;
+
+
+my $file1 = path(\'foo.txt');
+isa_ok( $file1, "Path::Tiny" );
+
+ok "$file1" eq "t/foo.txt", "Caller relative via ref";
+
+done_testing();


### PR DESCRIPTION
Using a reference to an unblessed scalar, create a path relative to the calling file instead of the current working directory.  This makes it easy to reference file located relative to the calling .pm or script file in a very concise way.

For example if a script located at "~/jsmith/test.pl" creates a Path::Tiny object like so:
my $path=path(\"foo.txt");  # or  Path::Tiny->new("foo.txt")

The resulting $path will be ~/jsmith/foo.txt, regardless of the current working dir.


Added two tests for  `path(...)` and `Path::Tiny->new(...)` path construction.


Thanks for your consideration

Ruben