### PR TITLE
validation: stop ignoring bogus arguments, throw exceptions

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -1484,14 +1484,23 @@ B<NOTE>: unlike Perl's builtin C<mkdir>, this will create intermediate paths
 similar to the Unix C<mkdir -p> command.  It will not error if applied to an
 existing directory.
 
+Passing a defined argument I<other> than a hash reference is an error, and an
+exception will be thrown.
+
 Current API available since 0.125.
 
 =cut
 
 sub mkdir {
-    my ( $self, $args ) = @_;
-    $args = {} unless ref $args eq 'HASH';
+    my ( $self, $args, @rest ) = @_;
+
+    $args = {} unless defined $args;
+    if (@rest || (defined $args && ref $args ne 'HASH')) {
+        $self->_throw('mkdir', undef, "method argument was given, but was not a hash reference");
+    }
+
     my $err;
+
     $args->{error} = \$err unless defined $args->{error};
     require File::Path;
     my @dirs;
@@ -1514,13 +1523,21 @@ sub mkdir {
 Like calling C<mkdir>, but returns the list of directories created or an empty list if
 the directories already exist, just like C<make_path>.
 
+Passing a defined argument I<other> than a hash reference is an error, and an
+exception will be thrown.
+
 Deprecated in 0.125.
 
 =cut
 
 sub mkpath {
-    my ( $self, $args ) = @_;
-    $args = {} unless ref $args eq 'HASH';
+    my ( $self, $args, @rest ) = @_;
+
+    $args = {} unless defined $args;
+    if (@rest || (defined $args && ref $args ne 'HASH')) {
+        $self->_throw('mkdir', undef, "method argument was given, but was not a hash reference");
+    }
+
     my $err;
     $args->{error} = \$err unless defined $args->{error};
     require File::Path;
@@ -1920,12 +1937,21 @@ C<rmdir> function instead.
 
 Current API available since 0.013.
 
+Passing a defined argument I<other> than a hash reference is an error, and an
+exception will be thrown.
+
 =cut
 
 sub remove_tree {
-    my ( $self, $args ) = @_;
+    my ( $self, $args, @rest ) = @_;
+
+    $args = {} unless defined $args;
+    if (@rest || (defined $args && ref $args ne 'HASH')) {
+        $self->_throw('mkdir', undef, "method argument was given, but was not a hash reference");
+    }
+
     return 0 if !-e $self->[PATH] && !-l $self->[PATH];
-    $args = {} unless ref $args eq 'HASH';
+
     my $err;
     $args->{error} = \$err unless defined $args->{error};
     $args->{safe}  = 1     unless defined $args->{safe};

--- a/t/filesystem.t
+++ b/t/filesystem.t
@@ -468,6 +468,20 @@ SKIP: {
       'spewing follows the link and replace the destination instead';
 }
 
+{
+    my $newtmp = Path::Tiny->tempdir;
+    my $to_delete = $newtmp->child('to-delete')->mkdir;
+
+    my $error = exception { $newtmp->remove_tree('to-delete'); };
+    like(
+      $error,
+      qr/method argument was given, but was not a hash reference/,
+      "passing a weird argument to ->remove_tree throws",
+    );
+
+    ok -d $newtmp, "we did not remove path after bad call to remove_tree";
+}
+
 # We don't have subsume so comment these out.  Keep in case we
 # implement it later
 

--- a/t/mkdir.t
+++ b/t/mkdir.t
@@ -28,5 +28,21 @@ if ( $^O ne 'MSWin32' ) {
     ok( -d $path2, "target directory created" );
 }
 
+{
+    for my $weird_args (
+        ["bogus"],  # a string, somebody thought it's the child name
+        [mode=>1],  # programmer forgot to wrap pairs in {...}
+        [{}, 1 ],   # valid {} but extra argument; oops!
+        [[]],       # weird mistake, but better to die than ignore
+    ) {
+        my $error = exception { $path->mkdir(@$weird_args) };
+        like(
+          $error,
+          qr/method argument was given, but was not a hash reference/,
+          "passing a weird argument to ->mkdir throws (@$weird_args)",
+        );
+    }
+}
+
 done_testing;
 # COPYRIGHT

--- a/t/mkpath.t
+++ b/t/mkpath.t
@@ -27,5 +27,21 @@ if ( $^O ne 'MSWin32' ) {
     ok( -d $path2, "target directory created" );
 }
 
+{
+    for my $weird_args (
+        ["bogus"],  # a string, somebody thought it's the child name
+        [mode=>1],  # programmer forgot to wrap pairs in {...}
+        [{}, 1 ],   # valid {} but extra argument; oops!
+        [[]],       # weird mistake, but better to die than ignore
+    ) {
+        my $error = exception { $path->mkpath(@$weird_args) };
+        like(
+          $error,
+          qr/method argument was given, but was not a hash reference/,
+          "passing a weird argument to ->mkpath throws (@$weird_args)",
+        );
+    }
+}
+
 done_testing;
 # COPYRIGHT


### PR DESCRIPTION
Some methods, most notably ->mkdir and ->mkpath and ->remove_tree, expected a single hash reference (or nothing) as an argument.  If passed a string (for example), they would treat it like {}.

This hid this broken code:

    path($root)->mkdir('name-of-child');

It would not create $root/name-of-child, but would ensure that $root existed, then return.

This code will notice extra or non-hashref arguments and raise an exception.  An explicit undef is permitted, although only out of a sense of caution.

This fixes #300 