### PR TITLE
feat: Add is_temporary method

### DIFF
--- a/lib/Path/Tiny.pm
+++ b/lib/Path/Tiny.pm
@@ -1267,6 +1267,23 @@ sub is_rootdir {
     return $self->[DIR] eq '/' && $self->[FILE] eq '';
 }
 
+=method is_temporary
+
+    my $temp = Path::Tiny->tempfile;
+    if ($temp->is_temporary) {
+        ...
+    }
+
+Returns true if the C<Path::Tiny> object was created by C<tempfile> or
+C<tempdir>.  Returns false otherwise.
+
+=cut
+
+sub is_temporary {
+    my ($self) = @_;
+    !!eval { $self->cached_temp; 1 };
+}
+
 =method iterator
 
     $iter = path("/tmp")->iterator( \%options );

--- a/t/temp.t
+++ b/t/temp.t
@@ -145,5 +145,14 @@ subtest "tempfile, instance method, overridden DIR" => sub {
     ok( $tempfile->parent ne $bd ), "DIR is overridden";
 };
 
+subtest "is_temporary" => sub {
+    my $tempdir = Path::Tiny->tempdir;
+    ok( $tempdir->is_temporary, "tempdir is temporary" );
+    my $tempfile = Path::Tiny->tempfile;
+    ok( $tempfile->is_temporary, "tempfile is temporary" );
+    my $path = path("abcdefg");
+    ok( !$path->is_temporary, "regular path is not temporary" );
+};
+
 done_testing;
 # COPYRIGHT


### PR DESCRIPTION
This is a tiny commit which adds an `is_temporary` method to determine whether the object represents a temporary file.  I find I use this enough that it might be useful  to others.  It looks like I'm not the only one (see #287).  Just the `is_temporary` method should suffice, as that can be followed by a `is_file` or `is_dir`.